### PR TITLE
Fix single-particle PSTN bug

### DIFF
--- a/src/simulation/elements/PSTN.cpp
+++ b/src/simulation/elements/PSTN.cpp
@@ -104,7 +104,7 @@ int Element_PSTN::update(UPDATE_FUNC_ARGS)
 					r = pmap[y+ry][x+rx];
 					if (!r)
 						continue;
-					if (TYP(r) == PT_PSTN)
+					if (TYP(r) == PT_PSTN && !parts[ID(r)].life)
 					{
 						bool movedPiston = false;
 						bool foundEnd = false;


### PR DESCRIPTION
Bugfix for old PSTN bug that resurfaced (tid = 21004). *It affects single-particle PSTNs with _at least_ one particle of extension, so there isn't any reason for anyone to depend on it for his save.

EDIT: I said too fast. id:2032994 depends on it. *On the other hand, fix-pstn-oddity hasn't broken anything yet. >:D