### PR TITLE
Removed unnecessary CleanString() function

### DIFF
--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -123,11 +123,6 @@ std::string format::CleanString(std::string dirtyString, bool ascii, bool color,
 	return dirtyString;
 }
 
-std::string format::CleanString(const char * dirtyData, bool ascii, bool color, bool newlines, bool numeric)
-{
-	return CleanString(std::string(dirtyData), ascii, color, newlines, numeric);
-}
-
 std::vector<char> format::VideoBufferToPTI(const VideoBuffer & vidBuf)
 {
 	std::vector<char> data;

--- a/src/Format.h
+++ b/src/Format.h
@@ -27,7 +27,6 @@ namespace format
 	std::string UnixtimeToDate(time_t unixtime, std::string dateFomat = "%d %b %Y");
 	std::string UnixtimeToDateMini(time_t unixtime);
 	std::string CleanString(std::string dirtyString, bool ascii, bool color, bool newlines, bool numeric = false);
-	std::string CleanString(const char * dirtyData, bool ascii, bool color, bool newlines, bool numeric = false);
 	std::vector<char> VideoBufferToPNG(const VideoBuffer & vidBuf);
 	std::vector<char> VideoBufferToBMP(const VideoBuffer & vidBuf);
 	std::vector<char> VideoBufferToPPM(const VideoBuffer & vidBuf);


### PR DESCRIPTION
Two `CleanString()` functions with the only differing thing the first parameter (`const char*` vs `std::string`); removed the one with `const char*` as first parameter since `std::string` can be constructed with `const char*`.