### PR TITLE
Temp. displayed using {aheat} not in celsius

### DIFF
--- a/src/simulation/Sign.cpp
+++ b/src/simulation/Sign.cpp
@@ -30,7 +30,7 @@ std::string sign::getText(Simulation *sim)
 			float aheat = 0.0f;
 			if (x>=0 && x<XRES && y>=0 && y<YRES)
 				aheat = sim->hv[y/CELL][x/CELL];
-			sprintf(buff, "%3.2f", aheat);
+			sprintf(buff, "%3.2f", aheat-273.15);
 		}
 		else if (!strcmp(signText,"{t}"))
 		{

--- a/src/simulation/Sign.cpp
+++ b/src/simulation/Sign.cpp
@@ -30,7 +30,7 @@ std::string sign::getText(Simulation *sim)
 			float aheat = 0.0f;
 			if (x>=0 && x<XRES && y>=0 && y<YRES)
 				aheat = sim->hv[y/CELL][x/CELL];
-			sprintf(buff, "%3.2f", aheat-273.15);
+			sprintf(buff, "Ambient Temp: %3.2f", aheat-273.15);
 		}
 		else if (!strcmp(signText,"{t}"))
 		{


### PR DESCRIPTION
Since it is displayed in celsius for {t}, shouldn't it be for {aheat} too? Just a consistency thing.