### PR TITLE
Fix STOR modded element processing

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -105,7 +105,7 @@ int Simulation::Load(int fullX, int fullY, GameSave * save)
 			{
 				tempPart.ctype = partMap[tempPart.ctype];
 			}
-		if (tempPart.type == PT_PIPE || tempPart.type == PT_PPIP)
+		if (tempPart.type == PT_PIPE || tempPart.type == PT_PPIP || tempPart.type == PT_STOR)
 		{
 			tempPart.tmp = partMap[tempPart.tmp&0xFF] | (tempPart.tmp&~0xFF);
 		}


### PR DESCRIPTION
fixes #460, again
There only existed .ctype processing, but the element stored in STOR is determined by its .tmp.