### PR TITLE
Make white space consistent

### DIFF
--- a/src/simulation/elements/CAUS.cpp
+++ b/src/simulation/elements/CAUS.cpp
@@ -26,7 +26,7 @@ Element_CAUS::Element_CAUS()
 
 	Weight = 1;
 
-	Temperature = R_TEMP+0.0f	+273.15f;
+	Temperature = R_TEMP + 0.0f	+ 273.15f;
 	HeatConduct = 70;
 	Description = "Caustic Gas, acts like ACID.";
 
@@ -48,37 +48,36 @@ Element_CAUS::Element_CAUS()
 int Element_CAUS::update(UPDATE_FUNC_ARGS)
 {
 	int r, rx, ry;
-	for (rx=-2; rx<3; rx++)
-		for (ry=-2; ry<3; ry++)
+	for (rx = -2; rx < 3; rx++)
+		for (ry = -2; ry < 3; ry++)
 			if (BOUNDS_CHECK && (rx || ry))
 			{
-				r = pmap[y+ry][x+rx];
+				r = pmap[y + ry][x + rx];
 				if (!r)
 					continue;
-				if ((r&0xFF) == PT_GAS)
+				if ((r & 0xFF) == PT_GAS)
 				{
-					if (sim->pv[(y+ry)/CELL][(x+rx)/CELL] > 3)
+					if (sim->pv[(y + ry) / CELL][(x + rx) / CELL] > 3)
 					{
-						sim->part_change_type(r>>8, x+rx, y+ry, PT_RFRG);
+						sim->part_change_type(r >> 8, x + rx, y + ry, PT_RFRG);
 						sim->part_change_type(i, x, y, PT_RFRG);
 					}
 				}
-				else if ((r&0xFF)!=PT_ACID && (r&0xFF)!=PT_CAUS && (r&0xFF)!=PT_RFRG && (r&0xFF)!=PT_RFGL)
+				else if ((r & 0xFF) != PT_ACID && (r & 0xFF) != PT_CAUS && (r & 0xFF) != PT_RFRG && (r & 0xFF) != PT_RFGL)
 				{
-					if (((r&0xFF)!=PT_CLNE && (r&0xFF)!=PT_PCLN && sim->elements[r&0xFF].Hardness>(rand()%1000))&&parts[i].life>=50)
+					if (((r & 0xFF) != PT_CLNE && (r & 0xFF) != PT_PCLN && sim->elements[r & 0xFF].Hardness > (rand() % 1000)) && parts[i].life >= 50)
 					{
-						if (sim->parts_avg(i, r>>8,PT_GLAS)!= PT_GLAS)//GLAS protects stuff from acid
+						if (sim->parts_avg(i, r >> 8, PT_GLAS) != PT_GLAS) // GLAS protects stuff from acid
 						{
-							float newtemp = ((60.0f-(float)sim->elements[r&0xFF].Hardness))*7.0f;
-							if(newtemp < 0){
-								newtemp = 0;
-							}
+							float newtemp = ((60.0f - (float) sim->elements[r & 0xFF].Hardness)) * 7.0f;
+							if (newtemp < 0)
+                                newtemp = 0;
 							parts[i].temp += newtemp;
 							parts[i].life--;
-							sim->kill_part(r>>8);
+							sim->kill_part(r >> 8);
 						}
 					}
-					else if (parts[i].life<=50)
+					else if (parts[i].life <= 50)
 					{
 						sim->kill_part(i);
 						return 1;


### PR DESCRIPTION
The white space wasn't consistent. For example if(...) vs if (...). Curly brackets placement inconsistency and more. Made the white space consistent with readability in mind.