### PR TITLE
Fix tpt.parts being unsafe

### DIFF
--- a/src/lua/LegacyLuaAPI.cpp
+++ b/src/lua/LegacyLuaAPI.cpp
@@ -32,6 +32,8 @@ int luacon_partread(lua_State* l)
 
 	if (i < 0 || i >= NPART)
 		return luaL_error(l, "Out of range");
+	if (!luacon_sim->parts[i].type)
+		return luaL_error(l, "dead particle");
 	if (offset == -1)
 	{
 		if (!key.compare("id"))
@@ -68,6 +70,8 @@ int luacon_partwrite(lua_State* l)
 
 	if (i < 0 || i >= NPART)
 		return luaL_error(l, "Out of range");
+	if (!luacon_sim->parts[i].type)
+		return luaL_error(l, "dead particle");
 	if (offset == -1)
 		return luaL_error(l, "Invalid property");
 
@@ -94,6 +98,11 @@ int luacon_partsread(lua_State* l)
 	if (i<0 || i>=NPART)
 	{
 		return luaL_error(l, "array index out of bounds");
+	}
+	
+	if (!luacon_sim->parts[i].type)
+	{
+		return luaL_error(l, "dead particle");
 	}
 
 	lua_rawgeti(l, LUA_REGISTRYINDEX, tptPart);


### PR DESCRIPTION
`tpt.parts` does check whether the particle ID it gets is valid, but it doesn't check whether that particle ID is used. One could modify the life property of dead particles to break the linked list of free particle IDs, thus potentially gaining the ability to read from or write to arbitrary addresses in memory.