### PR TITLE
Added compatibility mode for saves prior to version 88 with clone and spark.

### DIFF
--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -1082,6 +1082,12 @@ void GameSave::readOPS(char * data, int dataLength)
 							}
 						}
 						break;
+					case PT_CLNE:
+					case PT_BCLN:
+						if (savedVersion < 88)
+						{
+							particles[newIndex].flags |= FLAG_OLDCLNE;
+						}
 					}
 					//note: PSv was used in version 77.0 and every version before, add something in PSv too if the element is that old
 					newIndex++;

--- a/src/simulation/Elements.h
+++ b/src/simulation/Elements.h
@@ -38,6 +38,7 @@
 #define FLAG_WATEREQUAL 0x4 //if a liquid was already checked during equalization
 #define FLAG_MOVABLE  0x8 // compatibility with old saves (moving SPNG), only applies to SPNG
 #define FLAG_PHOTDECO  0x8 // compatibility with old saves (decorated photons), only applies to PHOT. Having the same value as FLAG_MOVABLE is fine because they apply to different elements, and this saves space for future flags,
+#define FLAG_OLDCLNE 0x8 // compatibility with old saves (old CLNE requirements), only applies to CLNE and BCLN.
 
 
 #define UPDATE_FUNC_ARGS Simulation* sim, int i, int x, int y, int surround_space, int nt, Particle *parts, int pmap[YRES][XRES]

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -2932,7 +2932,7 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 			parts[index].ctype = PT_DUST;
 			return index;
 		}
-		if (p==-2 && ((elements[type].Properties & PROP_DRAWONCTYPE) || type==PT_CRAY))
+		if (p==-2 && ((elements[type].Properties & PROP_DRAWONCTYPE) || type==PT_CRAY) && !((type==PT_CLNE || type==PT_BCLN) && parts[pmap[y][x]>>8].flags & FLAG_OLDCLNE))
 		{
 			parts[index].ctype = PT_SPRK;
 			return index;


### PR DESCRIPTION
Prior to version 88, SPRK couldn't be applied to clone by clicking it. This prevents clone placed in saves before then from being given SPRK. 

For testing, many saves by the user `webb` have this style of button that breaks due to this.