### PR TITLE
Make RFRG store old pressure in a less hideous way

### DIFF
--- a/src/simulation/elements/RFRG.cpp
+++ b/src/simulation/elements/RFRG.cpp
@@ -47,20 +47,18 @@ Element_RFRG::Element_RFRG()
 //#TPT-Directive ElementHeader Element_RFRG static int update(UPDATE_FUNC_ARGS)
 int Element_RFRG::update(UPDATE_FUNC_ARGS)
 {
-	float new_pressure = sim->pv[y/CELL][x/CELL];
-	float *old_pressure = (float *)&parts[i].tmp;
-	if (std::isnan(*old_pressure))
-	{
-		*old_pressure = new_pressure;
-		return 0;
-	}
+	// * I guess it could be 23 or something but I'll just leave it at 20 for now.
+	#define RFRG_PRESSURE_PRECISION 20
 	
+	float new_pressure = sim->pv[y/CELL][x/CELL];
+	float old_pressure = (float)parts[i].tmp / (1 << RFRG_PRESSURE_PRECISION);
+
 	// * 0 bar seems to be pressure value -256 in TPT, see Air.cpp. Also, 1 bar seems to be pressure value 0.
 	//   With those two values we can set up our pressure scale which states that ... the highest pressure
 	//   we can achieve in TPT is 2 bar. That's not particularly realistic, but good enough for TPT.
 	
-	parts[i].temp = restrict_flt(parts[i].temp * ((new_pressure + 257.f) / (*old_pressure + 257.f)), 0, MAX_TEMP);
-	*old_pressure = new_pressure;
+	parts[i].temp = restrict_flt(parts[i].temp * ((new_pressure + 257.f) / (old_pressure + 257.f)), 0, MAX_TEMP);
+	parts[i].tmp = restrict_flt(new_pressure, -256, 256) * (1 << RFRG_PRESSURE_PRECISION);
 	return 0;
 }
 


### PR DESCRIPTION
I've actually tested this and it looks more promising than the float version ever has been. Pressurising RFRG with temp=273 from p=0 to p=256 heats it up to temp=546±10. While not significantly superior to the float approach, it is better and doesn't cast pointers back and forth between int and float.

Further input required. I'm bad at running into edge cases, but I know some people out there are not. I summon them.