### PR TITLE
Fix Simulation::Restore decrementing life values

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -380,7 +380,7 @@ void Simulation::Restore(const Snapshot & snap)
 		parts[i].type = 0;
 	std::copy(snap.Particles.begin(), snap.Particles.end(), parts);
 	parts_lastActiveIndex = NPART-1;
-	RecalcFreeParticles();
+	RecalcFreeParticles(false);
 	std::copy(snap.PortalParticles.begin(), snap.PortalParticles.end(), &portalp[0][0][0]);
 	std::copy(snap.WirelessData.begin(), snap.WirelessData.end(), &wireless[0][0]);
 	if (grav->ngrav_enable)
@@ -4881,7 +4881,7 @@ void Simulation::SimulateGoL()
 	//memset(gol2, 0, sizeof(gol2));
 }
 
-void Simulation::RecalcFreeParticles()
+void Simulation::RecalcFreeParticles(bool do_life_dec)
 {
 	int x, y, t;
 	int lastPartUsed = 0;
@@ -4919,7 +4919,7 @@ void Simulation::RecalcFreeParticles()
 			NUM_PARTS ++;
 
 			//decrease particle life
-			if (!sys_pause || framerender)
+			if (do_life_dec && (!sys_pause || framerender))
 			{
 				if (t<0 || t>=PT_NUM || !elements[t].Enabled)
 				{
@@ -5078,7 +5078,7 @@ void Simulation::BeforeSim()
 	sandcolour = (int)(20.0f*sin((float)sandcolour_frame*(M_PI/180.0f)));
 	sandcolour_frame = (sandcolour_frame+1)%360;
 
-	RecalcFreeParticles();
+	RecalcFreeParticles(true);
 
 	if (!sys_pause || framerender)
 	{

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -159,7 +159,7 @@ public:
 	void create_arc(int sx, int sy, int dx, int dy, int midpoints, int variance, int type, int flags);
 	void UpdateParticles(int start, int end);
 	void SimulateGoL();
-	void RecalcFreeParticles();
+	void RecalcFreeParticles(bool do_life_dec);
 	void CheckStacking();
 	void BeforeSim();
 	void AfterSim();


### PR DESCRIPTION
`Simulation::Restore` used to call `Simulation::RecalcFreeParticles`. The problem with that was that `RecalcFreeParticles` does more than just what its name suggests: it also decrements life values. `Restore` shouldn't do that. The solution is to tie decrementing life values to an argument in `RecalcFreeParticles`. This is also makes to code more future-proof as it lets everyone know that they have to keep their eyes peeled when invoking `RecalcFreeParticles`.