### PR TITLE
Added a bounds check for BOMB reading pmap

### DIFF
--- a/src/simulation/elements/BOMB.cpp
+++ b/src/simulation/elements/BOMB.cpp
@@ -67,18 +67,22 @@ int Element_BOMB::update(UPDATE_FUNC_ARGS)
 						for (nxi=-rad; nxi<=rad; nxi++)
 							if ((pow((float)nxi,2))/(pow((float)rad,2))+(pow((float)nxj,2))/(pow((float)rad,2))<=1)
 							{
-								nt = pmap[y+nxj][x+nxi]&0xFF;
-								if (nt!=PT_DMND && nt!=PT_CLNE && nt!=PT_PCLN && nt!=PT_BCLN && nt!=PT_VIBR)
+								int ynxj = y + nxj, xnxi = x + nxi;
+								if (((ynxj > 0) && (ynxj < YRES)) && ((xnxi > 0) && (xnxi < XRES)))
 								{
-									if (nt)
-										sim->kill_part(pmap[y+nxj][x+nxi]>>8);
-									sim->pv[(y+nxj)/CELL][(x+nxi)/CELL] += 0.1f;
-									nb = sim->create_part(-3, x+nxi, y+nxj, PT_EMBR);
-									if (nb!=-1)
+									nt = pmap[ynxj][xnxi]&0xFF;
+									if (nt!=PT_DMND && nt!=PT_CLNE && nt!=PT_PCLN && nt!=PT_BCLN && nt!=PT_VIBR)
 									{
-										parts[nb].tmp = 2;
-										parts[nb].life = 2;
-										parts[nb].temp = MAX_TEMP;
+										if (nt)
+											sim->kill_part(pmap[ynxj][xnxi]>>8);
+										sim->pv[(ynxj)/CELL][(xnxi)/CELL] += 0.1f;
+										nb = sim->create_part(-3, xnxi, ynxj, PT_EMBR);
+										if (nb!=-1)
+										{
+											parts[nb].tmp = 2;
+											parts[nb].life = 2;
+											parts[nb].temp = MAX_TEMP;
+										}
 									}
 								}
 							}

--- a/src/simulation/elements/BOMB.cpp
+++ b/src/simulation/elements/BOMB.cpp
@@ -68,21 +68,22 @@ int Element_BOMB::update(UPDATE_FUNC_ARGS)
 							if ((pow((float)nxi,2))/(pow((float)rad,2))+(pow((float)nxj,2))/(pow((float)rad,2))<=1)
 							{
 								int ynxj = y + nxj, xnxi = x + nxi;
-								if (((ynxj > 0) && (ynxj < YRES)) && ((xnxi > 0) && (xnxi < XRES)))
+								
+								if ((ynxj < 0) || (ynxj >= YRES) || (xnxi <= 0) || (xnxi >= XRES))
+									continue;
+								
+								nt = pmap[ynxj][xnxi]&0xFF;
+								if (nt!=PT_DMND && nt!=PT_CLNE && nt!=PT_PCLN && nt!=PT_BCLN && nt!=PT_VIBR)
 								{
-									nt = pmap[ynxj][xnxi]&0xFF;
-									if (nt!=PT_DMND && nt!=PT_CLNE && nt!=PT_PCLN && nt!=PT_BCLN && nt!=PT_VIBR)
+									if (nt)
+										sim->kill_part(pmap[ynxj][xnxi]>>8);
+									sim->pv[(ynxj)/CELL][(xnxi)/CELL] += 0.1f;
+									nb = sim->create_part(-3, xnxi, ynxj, PT_EMBR);
+									if (nb!=-1)
 									{
-										if (nt)
-											sim->kill_part(pmap[ynxj][xnxi]>>8);
-										sim->pv[(ynxj)/CELL][(xnxi)/CELL] += 0.1f;
-										nb = sim->create_part(-3, xnxi, ynxj, PT_EMBR);
-										if (nb!=-1)
-										{
-											parts[nb].tmp = 2;
-											parts[nb].life = 2;
-											parts[nb].temp = MAX_TEMP;
-										}
+										parts[nb].tmp = 2;
+										parts[nb].life = 2;
+										parts[nb].temp = MAX_TEMP;
 									}
 								}
 							}


### PR DESCRIPTION
BOMB was reading out of the bounds for pmap, causing a huge value to be passed to kill_part. 