### PR TITLE
Fix deprecation warnings from pthread on Windows

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -472,7 +472,7 @@ elif GetOption('release'):
 
 if GetOption('static'):
 	if platform == "Windows":
-		env.Append(CPPDEFINES=['PTW32_STATIC_LIB'])
+		env.Append(CPPDEFINES=['_PTW32_STATIC_LIB'])
 		if msvc:
 			env.Append(CPPDEFINES=['ZLIB_WINAPI'])
 		else:


### PR DESCRIPTION
**This needs to be tested on older versions of pthread and gcc**