### PR TITLE
Implemented tooltip element descriptor display in element search.

### DIFF
--- a/src/gui/elementsearch/ElementSearchActivity.cpp
+++ b/src/gui/elementsearch/ElementSearchActivity.cpp
@@ -27,12 +27,13 @@ ElementSearchActivity::ElementSearchActivity(GameController * gameController, st
 	firstResult(NULL),
 	gameController(gameController),
 	tools(tools),
+	toolTip(""),
+	toolTipPresence(0),
 	shiftPressed(false),
 	ctrlPressed(false),
 	altPressed(false),
-	exit(false),
-	toolTip(""),
-	isToolTipFadingIn(false)
+	isToolTipFadingIn(false),
+	exit(false)
 {
 	ui::Label * title = new ui::Label(ui::Point(4, 5), ui::Point(Size.X-8, 15), "Element Search");
 	title->SetTextColour(style::Colour::InformationTitle);
@@ -211,7 +212,7 @@ void ElementSearchActivity::OnTick(float dt)
 		if (toolTipPresence < 120)
 			toolTipPresence += int(dt*2)>1?int(dt*2):2;
 	}
-	if (toolTipPresence>0)
+	else if (toolTipPresence>0)
 	{
 		toolTipPresence -= int(dt)>0?int(dt):1;
 		if (toolTipPresence<0)

--- a/src/gui/elementsearch/ElementSearchActivity.cpp
+++ b/src/gui/elementsearch/ElementSearchActivity.cpp
@@ -30,7 +30,9 @@ ElementSearchActivity::ElementSearchActivity(GameController * gameController, st
 	shiftPressed(false),
 	ctrlPressed(false),
 	altPressed(false),
-	exit(false)
+	exit(false),
+	toolTip(""),
+	isToolTipFadingIn(false)
 {
 	ui::Label * title = new ui::Label(ui::Point(4, 5), ui::Point(Size.X-8, 15), "Element Search");
 	title->SetTextColour(style::Colour::InformationTitle);
@@ -193,12 +195,28 @@ void ElementSearchActivity::OnDraw()
 	g->drawrect(Position.X, Position.Y, Size.X, Size.Y, 255, 255, 255, 255);
 
 	g->drawrect(Position.X+searchField->Position.X, Position.Y+searchField->Position.Y+searchField->Size.Y+8, searchField->Size.X, Size.Y-(searchField->Position.Y+searchField->Size.Y+8)-23, 255, 255, 255, 180);
+	if (toolTipPresence && toolTip.length())
+	{
+		g->drawtext(10, Size.Y+70, (char*)toolTip.c_str(), 255, 255, 255, toolTipPresence>51?255:toolTipPresence*5);
+	}
 }
 
 void ElementSearchActivity::OnTick(float dt)
 {
 	if (exit)
 		Exit();
+	if (isToolTipFadingIn)
+	{
+		isToolTipFadingIn = false;
+		if (toolTipPresence < 120)
+			toolTipPresence += int(dt*2)>1?int(dt*2):2;
+	}
+	if (toolTipPresence>0)
+	{
+		toolTipPresence -= int(dt)>0?int(dt):1;
+		if (toolTipPresence<0)
+			toolTipPresence = 0;
+	}
 }
 
 void ElementSearchActivity::OnKeyPress(int key, Uint16 character, bool shift, bool ctrl, bool alt)
@@ -244,6 +262,12 @@ void ElementSearchActivity::OnKeyRelease(int key, Uint16 character, bool shift, 
 		altPressed = false;
 		break;
 	}
+}
+
+void ElementSearchActivity::ToolTip(ui::Point senderPosition, std::string toolTip)
+{
+	this->toolTip = toolTip;
+	this->isToolTipFadingIn = true;
 }
 
 ElementSearchActivity::~ElementSearchActivity() {

--- a/src/gui/elementsearch/ElementSearchActivity.h
+++ b/src/gui/elementsearch/ElementSearchActivity.h
@@ -18,9 +18,12 @@ class ElementSearchActivity: public WindowActivity
 	std::vector<Tool*> tools;
 	ui::Textbox * searchField;
 	std::vector<ToolButton*> toolButtons;
+	std::string toolTip;
+	int toolTipPresence;
 	bool shiftPressed;
 	bool ctrlPressed;
 	bool altPressed;
+	bool isToolTipFadingIn;
 	void searchTools(std::string query);
 
 public:
@@ -30,10 +33,11 @@ public:
 	ElementSearchActivity(GameController * gameController, std::vector<Tool*> tools);
 	void SetActiveTool(int selectionState, Tool * tool);
 	virtual ~ElementSearchActivity();
-	virtual void OnDraw();
 	virtual void OnTick(float dt);
 	virtual void OnKeyPress(int key, Uint16 character, bool shift, bool ctrl, bool alt);
 	virtual void OnKeyRelease(int key, Uint16 character, bool shift, bool ctrl, bool alt);
+	virtual void OnDraw();
+	virtual void ToolTip(ui::Point senderPosition, std::string ToolTip);
 };
 
 #endif /* ELEMENTSEARCHACTIVITY_H_ */


### PR DESCRIPTION
Issue #289. Fixed hover tooltip feature in element search.
Hovering over an element icon in the element search window brings up element description.