### PR TITLE
Fix free particle list messing up during particle debug

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -5195,7 +5195,8 @@ void Simulation::BeforeSim()
 	sandcolour = (int)(20.0f*sin((float)sandcolour_frame*(M_PI/180.0f)));
 	sandcolour_frame = (sandcolour_frame+1)%360;
 
-	RecalcFreeParticles(true);
+	if (debug_currentParticle == 0)
+		RecalcFreeParticles(true);
 
 	if (!sys_pause || framerender)
 	{


### PR DESCRIPTION
It might be more elegant to only call BeforeSim once on save load rather than all the time, but this fix is easier and reflects particle debug's second-class status.

The problem that this fixes is that electronics that depend on ID stack invariance across particles (none published as of yet) would fail to work if particle debug is used to step through those particles one by one, since the free ID stack is recalculated every frame even if the frame is only half-updated. This fix only recalculates the ID stack if the frame has completed. It affects only the particle debug tool and thus will not affect the simulation of any existing or future saves.