### PR TITLE
Fix undoing changes in gravity mask

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -484,6 +484,7 @@ void Simulation::Restore(const Snapshot & snap)
 		std::copy(snap.GravValue.begin(), snap.GravValue.end(), gravp);
 		std::copy(snap.GravMap.begin(), snap.GravMap.end(), gravmap);
 	}
+	gravWallChanged = true;
 	std::copy(snap.BlockMap.begin(), snap.BlockMap.end(), &bmap[0][0]);
 	std::copy(snap.ElecMap.begin(), snap.ElecMap.end(), &emap[0][0]);
 	std::copy(snap.FanVelocityX.begin(), snap.FanVelocityX.end(), &fvx[0][0]);


### PR DESCRIPTION
Currently, gravity mask is not updated when undoing changes in it. For example, you can create gravity wall, undo it and there will be gravity mask without gravity wall.