### PR TITLE
Adds RAYT

### DIFF
--- a/src/client/GameSave.cpp
+++ b/src/client/GameSave.cpp
@@ -2699,7 +2699,7 @@ bool GameSave::TypeInCtype(int type, int ctype)
 	        type == PT_STOR || type == PT_CONV || type == PT_STKM || type == PT_STKM2 ||
 	        type == PT_FIGH || type == PT_LAVA || type == PT_SPRK || type == PT_PSTN ||
 	        type == PT_CRAY || type == PT_DTEC || type == PT_DRAY || type == PT_PIPE ||
-	        type == PT_PPIP);
+	        type == PT_PPIP || type == PT_RAYT);
 }
 
 bool GameSave::TypeInTmp(int type)

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3485,6 +3485,9 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 	case PT_FILT:
 		parts[i].tmp = v;
 		break;
+	case PT_RAYT:
+		parts[i].life = -1;
+		parts[i].tmp = -1;
 	default:
 		break;
 	}

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -3485,9 +3485,6 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 	case PT_FILT:
 		parts[i].tmp = v;
 		break;
-	case PT_RAYT:
-		parts[i].life = -1;
-		parts[i].tmp = -1;
 	default:
 		break;
 	}

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -56,7 +56,7 @@ Element_RAYT::Element_RAYT() {
 //#TPT-Directive ElementHeader Element_RAYT static int update(UPDATE_FUNC_ARGS)
 int Element_RAYT::update(UPDATE_FUNC_ARGS) {
 	int rx, ry, r = 0;
-	if (parts[i].life == -1 && parts[i].tmp == -1) {
+	if (parts[i].life == 0 && parts[i].tmp == 0) {
 		for (rx=-2; rx<3; rx++) {
 			for (ry=-2; ry<3; ry++) {
 				r = pmap[y+ry][x+rx];

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -1,0 +1,115 @@
+#include "simulation/Elements.h"
+//#TPT-Directive ElementClass Element_RAYT PT_RAYT 186
+Element_RAYT::Element_RAYT() {
+	Identifier = "DEFAULT_PT_RAYT";
+	Name = "RAYT";
+	Colour = PIXPACK(0x66ff66);
+	MenuVisible = 1;
+	MenuSection = SC_SENSOR;
+	Enabled = 1;
+
+	Advection = 0.0f;
+	AirDrag = 0.00f * CFDS;
+	AirLoss = 0.00f;
+	Loss = 0.00f;
+	Collision = 0.0f;
+	Gravity = 0.0f;
+	Diffusion = 0.00f;
+	HotAir = 0.000f	* CFDS;
+	Falldown = 0;
+
+	Flammable = 0;
+	Explosive = 0;
+	Meltable = 0;
+	Hardness = 0;
+
+	Weight = 100;
+
+	Temperature = 283.15f;
+	HeatConduct = 0;
+	Description = "RAYT scans in a certain direction until it detects a particle";
+
+	Properties = TYPE_SOLID | PROP_DRAWONCTYPE | PROP_NOCTYPEDRAW;
+
+	LowPressure = IPL;
+	LowPressureTransition = NT;
+	HighPressure = IPH;
+	HighPressureTransition = NT;
+	LowTemperature = ITL;
+	LowTemperatureTransition = NT;
+	HighTemperature = ITH;
+	HighTemperatureTransition = NT;
+
+	Update = &Element_RAYT::update;
+}
+
+#define INVERT_FILTER 0
+#define IGNORE_ENERGY 1
+
+//NOTES:
+// life and tmp is used to store the direction RAYT will scan in, and is initially set based on the nearest conductive particle's position
+// ctype is used to store the target element, if any. (NONE is treated as a wildcard)
+// tmp2 is used for settings (binary flags). The flags are as follows:
+// 10: Inverts the CTYPE filter so that the element in ctype is the only thing that doesn't trigger RAYT, instead of the opposite.
+// 01: Ignore energy particles
+
+//#TPT-Directive ElementHeader Element_RAYT static int update(UPDATE_FUNC_ARGS)
+int Element_RAYT::update(UPDATE_FUNC_ARGS) {
+	int rx, ry, r = 0;
+	if (parts[i].life == 0 && parts[i].tmp == 0) {
+		for (rx=-2; rx<3; rx++) {
+			for (ry=-2; ry<3; ry++) {
+				r = pmap[y+ry][x+rx];
+				if (!r)
+					continue;
+				int type = TYP(r);
+				if (type == PT_SPRK || type == PT_METL || type == PT_NSCN || type == PT_PSCN || type == PT_INSL) {
+					parts[i].life = rx;
+					parts[i].tmp = ry;
+					return 0;
+				}
+			}
+		}
+	} else {
+		// Stolen from DRAY
+		bool foundParticle = false;
+		bool isEnergy = false;
+		int p = 0;
+		for (int xStep = parts[i].life*-1, yStep = parts[i].tmp*-1, xCurrent = x+xStep, yCurrent = y+yStep; ; xCurrent+=xStep, yCurrent+=yStep) {
+			int rr;
+			// haven't found a particle yet, keep looking for one
+			// the first particle it sees decides whether it will copy energy particles or not
+			if (!foundParticle) {
+				rr = pmap[yCurrent][xCurrent];
+				if (!rr) {
+					rr = sim->photons[yCurrent][xCurrent];
+					if (rr) {
+						foundParticle = isEnergy = true;
+						p = rr;
+						break;
+					}
+				} else {
+					foundParticle = true;
+					p = rr;
+					break;
+				}
+			}
+		}
+		if (foundParticle == true) {
+			if (isEnergy) {
+				if ((parts[i].tmp2 & 1) && ((TYP(p) == TYP(parts[i].ctype)) xor (parts[i].tmp2 & (1 << 1)))) {
+					sim->part_change_type(ID(pmap[y+parts[i].tmp][x+parts[i].life]),x+parts[i].life,y+parts[i].tmp,PT_SPRK);
+					return 0;
+				} else {
+					return 0;
+				}
+			}
+			if ((TYP(p) == TYP(parts[i].ctype)) xor (parts[i].tmp2 & (1 << 1))) {
+				sim->part_change_type(ID(pmap[y+parts[i].tmp][x+parts[i].life]),x+parts[i].life,y+parts[i].tmp,PT_SPRK);
+			}
+		}
+	}
+	return 0;
+}
+
+Element_RAYT::~Element_RAYT() {}

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -56,7 +56,7 @@ Element_RAYT::Element_RAYT() {
 //#TPT-Directive ElementHeader Element_RAYT static int update(UPDATE_FUNC_ARGS)
 int Element_RAYT::update(UPDATE_FUNC_ARGS) {
 	int rx, ry, r = 0;
-	if (parts[i].life == 0 && parts[i].tmp == 0) {
+	if (parts[i].life == -1 && parts[i].tmp == -1) {
 		for (rx=-2; rx<3; rx++) {
 			for (ry=-2; ry<3; ry++) {
 				r = pmap[y+ry][x+rx];

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -28,7 +28,7 @@ Element_RAYT::Element_RAYT() {
 
 	Temperature = 283.15f;
 	HeatConduct = 0;
-	Description = "RAYT scans in a certain direction until it detects a particle";
+	Description = "RAYT scans in 8 directions for the element in its ctype and sparks the conductor on the opposite side";
 
 	Properties = TYPE_SOLID | PROP_DRAWONCTYPE | PROP_NOCTYPEDRAW;
 
@@ -48,7 +48,6 @@ Element_RAYT::Element_RAYT() {
 #define IGNORE_ENERGY 1
 
 //NOTES:
-// life and tmp is used to store the direction RAYT will scan in, and is initially set based on the nearest conductive particle's position
 // ctype is used to store the target element, if any. (NONE is treated as a wildcard)
 // tmp2 is used for settings (binary flags). The flags are as follows:
 // 10: Inverts the CTYPE filter so that the element in ctype is the only thing that doesn't trigger RAYT, instead of the opposite.
@@ -57,62 +56,72 @@ Element_RAYT::Element_RAYT() {
 //#TPT-Directive ElementHeader Element_RAYT static int update(UPDATE_FUNC_ARGS)
 int Element_RAYT::update(UPDATE_FUNC_ARGS) {
 	int rx, ry, r = 0;
-	for (rx=-2; rx<3; rx++) {
-		for (ry=-2; ry<3; ry++) {
-			if (BOUNDS_CHECK && (rx || ry) && x+rx>=0 && y+ry>=0 && x+rx<XRES && y+ry<YRES) {
+	for (rx = -1; rx <= 1; rx++)
+	{
+		for (ry = -1; ry <= 1; ry++)
+		{
+			if (BOUNDS_CHECK && (rx || ry) && x+rx>=0 && y+ry>=0 && x+rx<XRES && y+ry<YRES)
+			{
 				r = pmap[y+ry][x+rx];
 				if (!r)
 					continue;
 
 				int rt = TYP(r);
-				if ((sim->elements[rt].Properties&PROP_CONDUCTS) && !(rt==PT_WATR||rt==PT_SLTW||rt==PT_NTCT||rt==PT_PTCT||rt==PT_INWR) && parts[ID(r)].life==0) {
+				if ((sim->elements[rt].Properties&PROP_CONDUCTS) && !(rt==PT_WATR||rt==PT_SLTW||rt==PT_NTCT||rt==PT_PTCT||rt==PT_INWR) && parts[ID(r)].life==0)
+				{
 					// Stolen from DRAY
 					bool foundParticle = false;
 					bool isEnergy = false;
 					int p = 0;
-					for (int xStep = rx*-1, yStep = ry*-1, xCurrent = x+xStep, yCurrent = y+yStep; ; xCurrent+=xStep, yCurrent+=yStep) {
+					for (int xStep = rx*-1, yStep = ry*-1, xCurrent = x+xStep, yCurrent = y+yStep; ; xCurrent+=xStep, yCurrent+=yStep)
+					{
 						int rr;
-						if (!(xCurrent>=0 && yCurrent>=0 && xCurrent<XRES && yCurrent<YRES)) {
+						if (!(xCurrent>=0 && yCurrent>=0 && xCurrent<XRES && yCurrent<YRES))
+						{
 							break; // We're out of bounds! Oops!
 						}
-						// haven't found a particle yet, keep looking for one
-						if (!foundParticle) {
-							rr = pmap[yCurrent][xCurrent];
-							if (!rr) {
-								rr = sim->photons[yCurrent][xCurrent];
-									if (rr) {
-										foundParticle = isEnergy = true;
-										goto checks;
-										break;
-									}
-							} else {
-								foundParticle = true;
-								checks:
-								if (parts[i].ctype == PT_NONE && TYP(rr) != PT_NONE) {
-									parts[ID(r)].life = 4;
-									parts[ID(r)].ctype = rt;
-									sim->part_change_type(ID(r),x+rx,y+ry,PT_SPRK);
+						rr = pmap[yCurrent][xCurrent];
+						if (!rr)
+						{
+							rr = sim->photons[yCurrent][xCurrent];
+								if (rr)
+								{
+									isEnergy = true;
 								}
-								if (isEnergy) {
-									if ((parts[i].tmp2 & 1) && ((TYP(rr) == TYP(parts[i].ctype)) xor (parts[i].tmp2 & (1 << 1)))) {
-										if (sim->parts_avg(i,ID(r),PT_INSL) != PT_INSL) {
-											parts[ID(r)].life = 4;
-											parts[ID(r)].ctype = rt;
-											sim->part_change_type(ID(r),x+rx,y+ry,PT_SPRK);
-										}
-									} else {
-										break;
-									}
-								}
-								if ((TYP(rr) == TYP(parts[i].ctype)) xor (parts[i].tmp2 & (1 << 1))) {
-									if (sim->parts_avg(i,ID(r),PT_INSL) != PT_INSL) {
+						}
+						if (rr)
+						{
+							if (parts[i].ctype == PT_NONE && TYP(rr) != PT_NONE)
+							{
+								parts[ID(r)].life = 4;
+								parts[ID(r)].ctype = rt;
+								sim->part_change_type(ID(r),x+rx,y+ry,PT_SPRK);
+							}
+							if (isEnergy)
+							{
+								if ((parts[i].tmp2 & 1) && ((TYP(rr) == TYP(parts[i].ctype)) xor (parts[i].tmp2 & (1 << 1))))
+								{
+									if (sim->parts_avg(i,ID(r),PT_INSL) != PT_INSL)
+									{
 										parts[ID(r)].life = 4;
 										parts[ID(r)].ctype = rt;
 										sim->part_change_type(ID(r),x+rx,y+ry,PT_SPRK);
 									}
+								} else
+								{
+									break;
 								}
-								break;
 							}
+							if ((TYP(rr) == TYP(parts[i].ctype)) xor (parts[i].tmp2 & (1 << 1)))
+							{
+								if (sim->parts_avg(i,ID(r),PT_INSL) != PT_INSL)
+								{
+									parts[ID(r)].life = 4;
+									parts[ID(r)].ctype = rt;
+									sim->part_change_type(ID(r),x+rx,y+ry,PT_SPRK);
+								}
+							}
+							break;
 						}
 					}
 				}

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -1,3 +1,5 @@
+#ifdef defined(SNAPSHOT) || defined(DEBUG)
+
 #include "simulation/Elements.h"
 
 //#TPT-Directive ElementClass Element_RAYT PT_RAYT 186
@@ -133,3 +135,5 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS) {
 }
 
 Element_RAYT::~Element_RAYT() {}
+
+#endif

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -1,4 +1,4 @@
-#ifdef defined(SNAPSHOT) || defined(DEBUG)
+
 
 #include "simulation/Elements.h"
 
@@ -9,7 +9,11 @@ Element_RAYT::Element_RAYT() {
 	Colour = PIXPACK(0x66ff66);
 	MenuVisible = 1;
 	MenuSection = SC_SENSOR;
+	#if defined(SNAPSHOT) || defined(DEBUG)
 	Enabled = 1;
+	#else
+	Enabled = 0;
+	#endif
 
 	Advection = 0.0f;
 	AirDrag = 0.00f * CFDS;
@@ -135,5 +139,3 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS) {
 }
 
 Element_RAYT::~Element_RAYT() {}
-
-#endif

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -84,7 +84,7 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS)
 	{
 		for (ry = -1; ry <= 1; ry++)
 		{
-			if (BOUNDS_CHECK && (rx || ry) && x+rx>=0 && y+ry>=0 && x+rx<XRES && y+ry<YRES)
+			if (BOUNDS_CHECK && (rx || ry) && x+rx>0 && y+ry>0 && x+rx<=XRES && y+ry<=YRES)
 			{
 				r = pmap[y+ry][x+rx];
 				if (!r)
@@ -114,7 +114,7 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS)
 						if (!rr)
 							continue;
 
-						if (!phot_data_type(TYP(r)) )
+						if (!phot_data_type(TYP(r)))
 						{
 							if (parts[i].ctype == 0 || (parts[i].ctype == TYP(rr)) ^ (parts[i].tmp2 & mask_invert_filter))
 							{
@@ -129,7 +129,17 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS)
 							{
 								if ((phot_data_type(TYP(rr)) && !(parts[i].tmp2 & mask_no_copy_color)))
 								{
-									parts[ID(r)].ctype = Element_FILT::getWavelengths(&parts[ID(rr)]);
+									int nx = x+rx, ny = y+ry;
+									while (TYP(r) == PT_FILT)
+									{
+										parts[ID(r)].ctype = Element_FILT::getWavelengths(&parts[ID(rr)]);
+										nx += rx;
+										ny += ry;
+										if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
+											break;
+										r = pmap[ny][nx];
+									}
+
 									break;
 								}
 							}

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -92,7 +92,7 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS)
 
 				int rt = TYP(r);
 
-				if (accepted_type(sim, r) && parts[ID(r)].life == 0)
+				if (accepted_type(sim, r) && (parts[ID(r)].life == 0 || phot_data_type(TYP(r))))
 				{
 					// Stolen from DRAY
 					int xStep = rx*-1, yStep = ry*-1;
@@ -114,7 +114,7 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS)
 						if (!rr)
 							continue;
 
-						if (!phot_data_type(TYP(r)))
+						if (!phot_data_type(TYP(r)) )
 						{
 							if (parts[i].ctype == 0 || (parts[i].ctype == TYP(rr)) ^ (parts[i].tmp2 & mask_invert_filter))
 							{

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -2,7 +2,8 @@
 #include <iostream>
 
 //#TPT-Directive ElementClass Element_RAYT PT_RAYT 186
-Element_RAYT::Element_RAYT() {
+Element_RAYT::Element_RAYT()
+{
 	Identifier = "DEFAULT_PT_RAYT";
 	Name = "RAYT";
 	Colour = PIXPACK(0x66ff66);
@@ -45,108 +46,121 @@ Element_RAYT::Element_RAYT() {
 	Update = &Element_RAYT::update;
 }
 
-const int mask_invert_filter = 1<<0; // First flag
-const int mask_ignore_energy = 1<<1;
-const int mask_no_copy_color = 1<<2;
+const int mask_invert_filter =  0x1;
+const int mask_ignore_energy =  0x2;
+const int mask_no_copy_color =  0x4;
+const int mask_keep_searching = 0x8;
 
 //NOTES:
 // ctype is used to store the target element, if any. (NONE is treated as a wildcard)
 // life is used for the amount of pixels to skip before starting the scan. Starts just in front of the RAYT if 0.
 // tmp is the number of particles that will be scanned before scanning stops. Unbounded if 0.
 // tmp2 is used for settings (binary flags). The flags are as follows:
-// 1000: Inverts the CTYPE filter so that the element in ctype is the only thing that doesn't trigger RAYT, instead of the opposite.
-// 0100: Ignore energy particles
-// 0010: Ignore FILT
+// 0x01: Inverts the CTYPE filter so that the element in ctype is the only thing that doesn't trigger RAYT, instead of the opposite.
+// 0x02: Ignore energy particles
+// 0x04: Ignore FILT (do not use color copying mode)
+// 0x08: Keep searching even after finding a particle
 
-bool accepted_type(Simulation* sim, int part) {
-	int rt = TYP(part);
-	if ((sim->elements[rt].Properties & PROP_CONDUCTS) && !(rt == PT_WATR || rt == PT_SLTW || rt == PT_NTCT || rt == PT_PTCT || rt == PT_INWR)) {
+
+/* Returns true for particles that activate the special FILT color copying mode */
+bool phot_data_type(int rt)
+{
+	if (rt == PT_FILT || rt == PT_PHOT || rt == PT_BRAY)
 		return true;
-	} else if (rt == PT_FILT || rt == PT_PHOT || rt == PT_BRAY) {
-		return true;
-	}
 	return false;
 }
 
-bool phot_data_type(int rt) {
-	if (rt == PT_FILT || rt == PT_PHOT || rt == PT_BRAY) {
-		return true;
+/* Returns true for particles that start a ray search ("dtec" mode)
+ */
+bool accepted_type(Simulation* sim, int r)
+{
+	int rt = TYP(r);
+	if ((sim->elements[rt].Properties & PROP_CONDUCTS) && !(rt == PT_WATR || rt == PT_SLTW || rt == PT_NTCT || rt == PT_PTCT || rt == PT_INWR))
+	{
+		if (sim->parts[ID(r)].life == 0)
+			return true;
 	}
 	return false;
 }
-
 
 //#TPT-Directive ElementHeader Element_RAYT static int update(UPDATE_FUNC_ARGS)
 int Element_RAYT::update(UPDATE_FUNC_ARGS)
 {
-	int rx, ry, r = 0, max = parts[i].tmp + parts[i].life;
-	for (rx = -1; rx <= 1; rx++)
+	int max = parts[i].tmp + parts[i].life;
+	for (int rx = -1; rx <= 1; rx++)
 	{
-		for (ry = -1; ry <= 1; ry++)
+		for (int ry = -1; ry <= 1; ry++)
 		{
-			if (BOUNDS_CHECK && (rx || ry) && x+rx>0 && y+ry>0 && x+rx<=XRES && y+ry<=YRES)
+			if (BOUNDS_CHECK && (rx || ry))
 			{
-				r = pmap[y+ry][x+rx];
+				int r = pmap[y+ry][x+rx];
 				if (!r)
 					continue;
 
-				int rt = TYP(r);
+				if (!accepted_type(sim, r) && ((parts[i].tmp2 & mask_no_copy_color) || !phot_data_type(TYP(r))))
+					continue;
 
-				if (accepted_type(sim, r) && (parts[ID(r)].life == 0 || phot_data_type(TYP(r))))
+				// Stolen from DRAY, does the ray searching
+				int xStep = rx * -1, yStep = ry * -1;
+				int xCurrent = x + (xStep * (parts[i].life + 1)), yCurrent = y + (yStep * (parts[i].life + 1));
+				for (;(parts[i].tmp == 0) || !(xCurrent - x >= max) || (yCurrent-y >= max); xCurrent += xStep, yCurrent += yStep)
 				{
-					// Stolen from DRAY
-					int xStep = rx*-1, yStep = ry*-1;
-					int xCurrent = x+(xStep*(parts[i].life+1)), yCurrent = y+(yStep*(parts[i].life+1));
-					for (;(parts[i].tmp == 0) || !(xCurrent-x >= max) || (yCurrent-y >= max);xCurrent+=xStep, yCurrent+=yStep)
+					int rr = pmap[yCurrent][xCurrent];
+					if (!(xCurrent>=0 && yCurrent>=0 && xCurrent<XRES && yCurrent<YRES))
 					{
-						int rr = pmap[yCurrent][xCurrent];
-						if (!(xCurrent>=0 && yCurrent>=0 && xCurrent<XRES && yCurrent<YRES))
+						break; // We're out of bounds! Oops!
+					}
+					if (!rr)
+					{
+						rr = sim->photons[yCurrent][xCurrent];
+						if (!(rr && !(parts[i].tmp2 & mask_ignore_energy)))
 						{
-							break; // We're out of bounds! Oops!
-						}
-						if (!rr)
-						{
-							rr = sim->photons[yCurrent][xCurrent];
-							if (!(rr && !(parts[i].tmp2 & mask_ignore_energy))) {
-								continue;
-							}
-						}
-						if (!rr)
 							continue;
+						}
+					}
+					if (!rr)
+						continue;
 
-						if (!phot_data_type(TYP(r)))
+					// Usual DTEC-like mode
+					if (!phot_data_type(TYP(r)))
+					{
+						// If ctype isn't set (no type restriction), or ctype matches what we found
+						// Can use .tmp2 flag to invert this
+						if (parts[i].ctype == 0 || (parts[i].ctype == TYP(rr)) ^ (parts[i].tmp2 & mask_invert_filter))
 						{
-							if (parts[i].ctype == 0 || (parts[i].ctype == TYP(rr)) ^ (parts[i].tmp2 & mask_invert_filter))
+							parts[ID(r)].life = 4;
+							parts[ID(r)].ctype = TYP(r);
+							sim->part_change_type(ID(r), xCurrent, yCurrent, PT_SPRK);
+							break;
+						}
+						// room for more conditions here.
+					}
+					// FILT color copying mode
+					else
+					{
+						// If ctype isn't set (no type restriction), or ctype matches what we found
+						// Can use .tmp2 flag to invert this
+						if (parts[i].ctype == 0 || (parts[i].ctype == TYP(rr)) ^ (parts[i].tmp2 & mask_invert_filter))
+						{
+							if (phot_data_type(TYP(rr)))
 							{
-								parts[ID(r)].life = 4;
-								parts[ID(r)].ctype = TYP(r);
-								sim->part_change_type(ID(r), xCurrent, yCurrent, PT_SPRK);
-								break;
-							}
-							// room for more conditions here.
-						} else {
-							if (parts[i].ctype == 0 || (parts[i].ctype == TYP(rr)) ^ (parts[i].tmp2 & mask_invert_filter))
-							{
-								if ((phot_data_type(TYP(rr)) && !(parts[i].tmp2 & mask_no_copy_color)))
+								int nx = x + rx, ny = y + ry;
+								while (TYP(r) == PT_FILT)
 								{
-									int nx = x+rx, ny = y+ry;
-									while (TYP(r) == PT_FILT)
-									{
-										parts[ID(r)].ctype = Element_FILT::getWavelengths(&parts[ID(rr)]);
-										nx += rx;
-										ny += ry;
-										if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
-											break;
-										r = pmap[ny][nx];
-									}
-
-									break;
+									parts[ID(r)].ctype = Element_FILT::getWavelengths(&parts[ID(rr)]);
+									nx += rx;
+									ny += ry;
+									if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
+										break;
+									r = pmap[ny][nx];
 								}
+								break;
 							}
 						}
 					}
+					if (!(parts[i].tmp2 & mask_keep_searching))
+						break;
 				}
-				continue;
 			}
 		}
 	}

--- a/src/simulation/elements/RAYT.cpp
+++ b/src/simulation/elements/RAYT.cpp
@@ -51,6 +51,8 @@ const int mask_no_copy_color = 1<<2;
 
 //NOTES:
 // ctype is used to store the target element, if any. (NONE is treated as a wildcard)
+// life is used for the amount of pixels to skip before starting the scan. Starts just in front of the RAYT if 0.
+// tmp is the number of particles that will be scanned before scanning stops. Unbounded if 0.
 // tmp2 is used for settings (binary flags). The flags are as follows:
 // 1000: Inverts the CTYPE filter so that the element in ctype is the only thing that doesn't trigger RAYT, instead of the opposite.
 // 0100: Ignore energy particles
@@ -77,7 +79,7 @@ bool phot_data_type(int rt) {
 //#TPT-Directive ElementHeader Element_RAYT static int update(UPDATE_FUNC_ARGS)
 int Element_RAYT::update(UPDATE_FUNC_ARGS)
 {
-	int rx, ry, r = 0;
+	int rx, ry, r = 0, max = parts[i].tmp + parts[i].life;
 	for (rx = -1; rx <= 1; rx++)
 	{
 		for (ry = -1; ry <= 1; ry++)
@@ -95,7 +97,7 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS)
 					// Stolen from DRAY
 					int xStep = rx*-1, yStep = ry*-1;
 					int xCurrent = x+(xStep*(parts[i].life+1)), yCurrent = y+(yStep*(parts[i].life+1));
-					for (;(parts[i].tmp == 0) || !(xCurrent-x >= parts[i].tmp) || (yCurrent-y >= parts[i].tmp);xCurrent+=xStep, yCurrent+=yStep)
+					for (;(parts[i].tmp == 0) || !(xCurrent-x >= max) || (yCurrent-y >= max);xCurrent+=xStep, yCurrent+=yStep)
 					{
 						int rr = pmap[yCurrent][xCurrent];
 						if (!(xCurrent>=0 && yCurrent>=0 && xCurrent<XRES && yCurrent<YRES))
@@ -128,7 +130,6 @@ int Element_RAYT::update(UPDATE_FUNC_ARGS)
 								if ((phot_data_type(TYP(rr)) && !(parts[i].tmp2 & mask_no_copy_color)))
 								{
 									parts[ID(r)].ctype = Element_FILT::getWavelengths(&parts[ID(rr)]);
-									parts[ID(r)].tmp = 8008; // verifying it works.
 									break;
 								}
 							}


### PR DESCRIPTION
This PR adds RAYT.
RAYT is a DTEC like element that scans in a line until it hits a particle, and emits an electric signal if the detected particle is that of it's CTYPE (Or not, i'll explain in a moment).
It also will attempt to copy the wavelength of distant FILT/PHOT/BRAY into a neighbouring FILT/BRAY if applicable.

RAYT uses the following properties:
ctype: Stores what element the RAYT should (or should not) be looking for. When set to PT_NONE, RAYT will trigger when hitting ANY element.
life: Stores how many pixels to skip before scanning. Skips nothing if 0.
tmp: Stores how many pixels to scan before stopping. Unbounded if 0.
tmp2: Stores flags. The flags are as follows, in binary:

- 100: Inverts the CTYPE filter so that the element in ctype is the only thing that doesn't trigger RAYT, instead of it being the only trigger.
- 010: Ignore energy particles.
- 001: DONT copy wavelengths from distant FILT/PHOT/BRAY into neighbouring FILT/BRAY.

----

RAYT's direction is set based on where a conductive particle is nearby. For each conductive particle, it will perform one scan for that particle. This means one RAYT particle can sense in multiple straight lines if you want, but normally does not.
This also applies for FILT/BRAY, they also set the direction, using the "copy wavelengths" mode instead.