### PR TITLE
Add Cyclone Tool and Brush X/Y Arguments

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -194,7 +194,7 @@ class {0}: public SimTool
 public:
 	{0}();
 	virtual ~{0}();
-	virtual int Perform(Simulation * sim, Particle * cpart, int x, int y, float strength);
+	virtual int Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength);
 }};
 """.format(className, str.join("\n", classMembers))
 	

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1274,8 +1274,8 @@ void Simulation::ToolLine(int x1, int y1, int x2, int y2, int tool, Brush * cBru
 void Simulation::ToolBox(int x1, int y1, int x2, int y2, int tool, float strength)
 {
 	int brushX, brushY;
-	brushX = ((x1 + x2) >> 1);
-	brushY = ((y1 + y2) >> 1);
+	brushX = ((x1 + x2) / 2);
+	brushY = ((y1 + y2) / 2);
 	int i, j;
 	if (x1>x2)
 	{

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -1190,7 +1190,7 @@ void Simulation::ApplyDecorationFill(Renderer *ren, int x, int y, int colR, int 
 	free(bitmap);
 }
 
-int Simulation::Tool(int x, int y, int tool, float strength)
+int Simulation::Tool(int x, int y, int tool, int brushX, int brushY, float strength)
 {
 	if(tools[tool])
 	{
@@ -1200,7 +1200,7 @@ int Simulation::Tool(int x, int y, int tool, float strength)
 			cpart = &(parts[ID(r)]);
 		else if ((r = photons[y][x]))
 			cpart = &(parts[ID(r)]);
-		return tools[tool]->Perform(this, cpart, x, y, strength);
+		return tools[tool]->Perform(this, cpart, x, y, brushX, brushY, strength);
 	}
 	return 0;
 }
@@ -1214,7 +1214,7 @@ int Simulation::ToolBrush(int positionX, int positionY, int tool, Brush * cBrush
 		for(int y = 0; y < sizeY; y++)
 			for(int x = 0; x < sizeX; x++)
 				if(bitmap[(y*sizeX)+x] && (positionX+(x-radiusX) >= 0 && positionY+(y-radiusY) >= 0 && positionX+(x-radiusX) < XRES && positionY+(y-radiusY) < YRES))
-					Tool(positionX+(x-radiusX), positionY+(y-radiusY), tool, strength);
+					Tool(positionX + (x - radiusX), positionY + (y - radiusY), tool, positionX, positionY, strength);
 	}
 	return 0;
 }
@@ -1273,6 +1273,9 @@ void Simulation::ToolLine(int x1, int y1, int x2, int y2, int tool, Brush * cBru
 }
 void Simulation::ToolBox(int x1, int y1, int x2, int y2, int tool, float strength)
 {
+	int brushX, brushY;
+	brushX = ((x1 + x2) >> 1);
+	brushY = ((y1 + y2) >> 1);
 	int i, j;
 	if (x1>x2)
 	{
@@ -1288,7 +1291,7 @@ void Simulation::ToolBox(int x1, int y1, int x2, int y2, int tool, float strengt
 	}
 	for (j=y1; j<=y2; j++)
 		for (i=x1; i<=x2; i++)
-			Tool(i, j, tool, strength);
+			Tool(i, j, tool, brushX, brushY, strength);
 }
 
 int Simulation::CreateWalls(int x, int y, int rx, int ry, int wall, Brush * cBrush)

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -177,7 +177,7 @@ public:
 	void ApplyDecorationFill(Renderer *ren, int x, int y, int colR, int colG, int colB, int colA, int replaceR, int replaceG, int replaceB);
 
 	//Drawing Tools like HEAT, AIR, and GRAV
-	int Tool(int x, int y, int tool, float strength = 1.0f);
+	int Tool(int x, int y, int tool, int brushX, int brushY, float strength = 1.0f);
 	int ToolBrush(int x, int y, int tool, Brush * cBrush, float strength = 1.0f);
 	void ToolLine(int x1, int y1, int x2, int y2, int tool, Brush * cBrush, float strength = 1.0f);
 	void ToolBox(int x1, int y1, int x2, int y2, int tool, float strength = 1.0f);

--- a/src/simulation/simtools/AirTool.cpp
+++ b/src/simulation/simtools/AirTool.cpp
@@ -9,7 +9,7 @@ Tool_Air::Tool_Air()
 	Description = "Air, creates airflow and pressure.";
 }
 
-int Tool_Air::Perform(Simulation * sim, Particle * cpart, int x, int y, float strength)
+int Tool_Air::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
 	sim->air->pv[y/CELL][x/CELL] += strength*0.05f;
 

--- a/src/simulation/simtools/Cool.cpp
+++ b/src/simulation/simtools/Cool.cpp
@@ -8,7 +8,7 @@ Tool_Cool::Tool_Cool()
 	Description = "Cools the targeted element.";
 }
 
-int Tool_Cool::Perform(Simulation * sim, Particle * cpart, int x, int y, float strength)
+int Tool_Cool::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
 	if(!cpart)
 		return 0;

--- a/src/simulation/simtools/Cyclone.cpp
+++ b/src/simulation/simtools/Cyclone.cpp
@@ -6,48 +6,38 @@ Tool_Cycl::Tool_Cycl()
 	Identifier = "DEFAULT_TOOL_CYCL";
 	Name = "CYCL";
 	Colour = PIXPACK(0x132f5b);
-	Description = "Cyclone. Produces Swirling Air Currents";
+	Description = "Cyclone. Produces swirling air currents";
 }
 
 int Tool_Cycl::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
 	/* 
 		Air velocity calculation.
-		Air velocity Y = Sine of cell angle
-		Angle of cell is calculated via cells X/Y relation to the brush center and ArcTangent
-		Angle has 1.57 Radians added to it (90 degrees) in order to make the velocity be at 90 degrees to the centerpoint.
-		Ditto for X, except X uses Cosine
+		Air velocity X = cosine of cell angle
+		Angle of cell is calculated via cells X/Y relation to the brush center and arctangent
+		Angle has 1.57 radians added to it (90 degrees) in order to make the velocity be at 90 degrees to the centerpoint.
+		Ditto for X, except X uses sine
 	*/
-	
-
+	// only trigger once per cell (less laggy)
 	if ((x%CELL) == 0 && (y%CELL) == 0)
 	{
-		sim->air->vy[y / CELL][x / CELL] -= (strength / 16) * (sin(1.57f + (atan2(brushY - y, brushX - x))));
-		sim->air->vx[y / CELL][x / CELL] -= (strength / 16) * (cos(1.57f + (atan2(brushY - y, brushX - x))));
+		float *vx = &sim->air->vx[y/CELL][x/CELL];
+		float *vy = &sim->air->vy[y/CELL][x/CELL];
+
+		*vx -= (strength / 16) * (cos(1.57f + (atan2(brushY - y, brushX - x))));
+		*vy -= (strength / 16) * (sin(1.57f + (atan2(brushY - y, brushX - x))));
+
+		// Clamp velocities
+		if (*vx > 256.0f)
+			*vx = 256.0f;
+		else if (*vx < -256.0f)
+			*vx = -256.0f;
+		if (*vy > 256.0f)
+			*vy = 256.0f;
+		else if (*vy < -256.0f)
+			*vy = -256.0f;
+
 	}
-
-
-
-	// Clamp velocities
-
-	if (sim->air->vx[y / CELL][x / CELL] > 256.0f)
-	{
-		sim->air->vx[y / CELL][x / CELL] = 256.0f;
-	}
-	if (sim->air->vy[y / CELL][x / CELL] > 256.0f)
-	{
-		sim->air->vy[y / CELL][x / CELL] = 256.0f;
-	}
-
-	if (sim->air->vx[y / CELL][x / CELL] < -256.0f)
-	{
-		sim->air->vx[y / CELL][x / CELL] = -256.0f;
-	}
-	if (sim->air->vy[y / CELL][x / CELL] < -256.0f)
-	{
-		sim->air->vy[y / CELL][x / CELL] = -256.0f;
-	}
-
 
 	return 1;
 }

--- a/src/simulation/simtools/Cyclone.cpp
+++ b/src/simulation/simtools/Cyclone.cpp
@@ -1,0 +1,64 @@
+#include "ToolClasses.h"
+#include "simulation/Air.h"
+//#TPT-Directive ToolClass Tool_Cycl TOOL_CYCL 8
+Tool_Cycl::Tool_Cycl()
+{
+	Identifier = "DEFAULT_TOOL_CYCL";
+	Name = "CYCL";
+	Colour = PIXPACK(0x132f5b);
+	Description = "Cyclone. Produces Swirling Air Currents";
+}
+
+int Tool_Cycl::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
+{
+	/* 
+		Air velocity calculation.
+		Air velocity Y = Sine of cell angle
+		Angle of cell is calculated via cells X/Y relation to the brush center and ArcTangent
+		Angle has 1.57 Radians added to it (90 degrees) in order to make the velocity be at 90 degrees to the centerpoint.
+		Ditto for X, except X uses Cosine
+
+		Strength is changed on CELL != 4 due to the fact that the calculation will be run 16x as much.
+	*/
+	
+	// Cell size of 4 optimization (greatly needed)
+	
+#if CELL == 4
+	if ((x & 3) == 0 && (y & 3) == 0)
+	{
+		sim->air->vy[y / CELL][x / CELL] -= (strength / 16) * (sin(1.57f + (atan2(brushY - y, brushX - x))));
+		sim->air->vx[y / CELL][x / CELL] -= (strength / 16) * (cos(1.57f + (atan2(brushY - y, brushX - x))));
+	}
+
+
+#else
+	sim->air->vy[y / CELL][x / CELL] -= (strength / 256) * (sin(1.57f + (atan2(brushY - y, brushX - x))));
+	sim->air->vx[y / CELL][x / CELL] -= (strength / 256) * (cos(1.57f + (atan2(brushY - y, brushX - x))));
+
+#endif /* CELL == 4*/
+
+	// Clamp velocities
+
+	if (sim->air->vx[y / CELL][x / CELL] > 256.0f)
+	{
+		sim->air->vx[y / CELL][x / CELL] = 256.0f;
+	}
+	if (sim->air->vy[y / CELL][x / CELL] > 256.0f)
+	{
+		sim->air->vy[y / CELL][x / CELL] = 256.0f;
+	}
+
+	if (sim->air->vx[y / CELL][x / CELL] < -256.0f)
+	{
+		sim->air->vx[y / CELL][x / CELL] = -256.0f;
+	}
+	if (sim->air->vy[y / CELL][x / CELL] < -256.0f)
+	{
+		sim->air->vy[y / CELL][x / CELL] = -256.0f;
+	}
+
+
+	return 1;
+}
+
+Tool_Cycl::~Tool_Cycl() {}

--- a/src/simulation/simtools/Cyclone.cpp
+++ b/src/simulation/simtools/Cyclone.cpp
@@ -17,25 +17,16 @@ int Tool_Cycl::Perform(Simulation * sim, Particle * cpart, int x, int y, int bru
 		Angle of cell is calculated via cells X/Y relation to the brush center and ArcTangent
 		Angle has 1.57 Radians added to it (90 degrees) in order to make the velocity be at 90 degrees to the centerpoint.
 		Ditto for X, except X uses Cosine
-
-		Strength is changed on CELL != 4 due to the fact that the calculation will be run 16x as much.
 	*/
 	
-	// Cell size of 4 optimization (greatly needed)
-	
-#if CELL == 4
-	if ((x & 3) == 0 && (y & 3) == 0)
+
+	if ((x%CELL) == 0 && (y%CELL) == 0)
 	{
 		sim->air->vy[y / CELL][x / CELL] -= (strength / 16) * (sin(1.57f + (atan2(brushY - y, brushX - x))));
 		sim->air->vx[y / CELL][x / CELL] -= (strength / 16) * (cos(1.57f + (atan2(brushY - y, brushX - x))));
 	}
 
 
-#else
-	sim->air->vy[y / CELL][x / CELL] -= (strength / 256) * (sin(1.57f + (atan2(brushY - y, brushX - x))));
-	sim->air->vx[y / CELL][x / CELL] -= (strength / 256) * (cos(1.57f + (atan2(brushY - y, brushX - x))));
-
-#endif /* CELL == 4*/
 
 	// Clamp velocities
 

--- a/src/simulation/simtools/Heat.cpp
+++ b/src/simulation/simtools/Heat.cpp
@@ -8,7 +8,7 @@ Tool_Heat::Tool_Heat()
 	Description = "Heats the targeted element.";
 }
 
-int Tool_Heat::Perform(Simulation * sim, Particle * cpart, int x, int y, float strength)
+int Tool_Heat::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
 	if(!cpart)
 		return 0;

--- a/src/simulation/simtools/Mix.cpp
+++ b/src/simulation/simtools/Mix.cpp
@@ -8,7 +8,7 @@ Tool_Mix::Tool_Mix()
 	Description = "Mixes particles.";
 }
 
-int Tool_Mix::Perform(Simulation * sim, Particle * cpart, int x, int y, float strength)
+int Tool_Mix::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
 	int thisPart = sim->pmap[y][x];
 	if(!thisPart)

--- a/src/simulation/simtools/NGrv.cpp
+++ b/src/simulation/simtools/NGrv.cpp
@@ -9,7 +9,7 @@ Tool_NGrv::Tool_NGrv()
 	Description = "Creates a short-lasting negative gravity well.";
 }
 
-int Tool_NGrv::Perform(Simulation * sim, Particle * cpart, int x, int y, float strength)
+int Tool_NGrv::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushYy, float strength)
 {
 	sim->gravmap[((y/CELL)*(XRES/CELL))+(x/CELL)] = strength*-5.0f;
 	return 1;

--- a/src/simulation/simtools/PGrv.cpp
+++ b/src/simulation/simtools/PGrv.cpp
@@ -9,7 +9,7 @@ Tool_PGrv::Tool_PGrv()
 	Description = "Creates a short-lasting gravity well.";
 }
 
-int Tool_PGrv::Perform(Simulation * sim, Particle * cpart, int x, int y, float strength)
+int Tool_PGrv::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
 	sim->gravmap[((y/CELL)*(XRES/CELL))+(x/CELL)] = strength*5.0f;
 	return 1;

--- a/src/simulation/simtools/SimTool.h
+++ b/src/simulation/simtools/SimTool.h
@@ -17,7 +17,7 @@ public:
 	
 	SimTool();
 	virtual ~SimTool() {}
-	virtual int Perform(Simulation * sim, Particle * cpart, int x, int y, float strength) { return 0; }
+	virtual int Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength) { return 0; }
 };
 
 #endif

--- a/src/simulation/simtools/Vac.cpp
+++ b/src/simulation/simtools/Vac.cpp
@@ -9,7 +9,7 @@ Tool_Vac::Tool_Vac()
 	Description = "Vacuum, reduces air pressure.";
 }
 
-int Tool_Vac::Perform(Simulation * sim, Particle * cpart, int x, int y, float strength)
+int Tool_Vac::Perform(Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
 	sim->air->pv[y/CELL][x/CELL] -= strength*0.05f;
 


### PR DESCRIPTION
Adds a cyclone tool to the game, which creates spinning air currents.

Required addition of brush X/Y arguments being passed to the brush functions, now new tools can use them :D

Updated generator.py to support new arguments!