### PR TITLE
fix prot + sprk(spwn or spwn2) crash

### DIFF
--- a/src/simulation/elements/PROT.cpp
+++ b/src/simulation/elements/PROT.cpp
@@ -58,7 +58,7 @@ int Element_PROT::update(UPDATE_FUNC_ARGS)
 	{
 		//remove active sparks
 		int sparked = parts[uID].ctype;
-		if (sparked > 0 && sparked < PT_NUM && sim->elements[sparked].Enabled)
+		if (sparked > 0 && sparked != PT_SPAWN && sparked != PT_SPAWN2 && sparked < PT_NUM && sim->elements[sparked].Enabled)
 		{
 			sim->part_change_type(uID, x, y, sparked);
 			parts[uID].life = 44 + parts[uID].life;


### PR DESCRIPTION
looks like the original sprk+prot crash wasn't fixed properly.

I found the bug, and huge credits to LBPHacker for finding the root cause, which I never would have figured out myself. Thanks, LBP :)