### PR TITLE
Fix mime-info format

### DIFF
--- a/resources/powdertoy-save.xml
+++ b/resources/powdertoy-save.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-	<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
 	<mime-type type="application/vnd.powdertoy.save">
 		<comment>Powder Toy save</comment>
-		<glob pattern=*.cps/>
-		<glob pattern=*.stm/>
-	</mime-type>"
+		<glob pattern="*.cps"/>
+		<glob pattern="*.stm"/>
+	</mime-type>
 </mime-info>


### PR DESCRIPTION
update-mime-info may fail to parse the file if attributes are not
between quotes.