### PR TITLE
Fix PIPE being reversed

### DIFF
--- a/src/simulation/elements/PIPE.cpp
+++ b/src/simulation/elements/PIPE.cpp
@@ -75,7 +75,7 @@ Element_PIPE::Element_PIPE()
 signed char pos_1_rx[] = {-1,-1,-1, 0, 0, 1, 1, 1};
 signed char pos_1_ry[] = {-1, 0, 1,-1, 1,-1, 0, 1};
 
-unsigned int nextColor(unsigned int flags)
+unsigned int prevColor(unsigned int flags)
 {
 	unsigned int color = flags & PFLAG_COLORS;
 	if (color == PFLAG_COLOR_RED)
@@ -87,7 +87,7 @@ unsigned int nextColor(unsigned int flags)
 	return PFLAG_COLOR_RED;
 }
 
-unsigned int prevColor(unsigned int flags)
+unsigned int nextColor(unsigned int flags)
 {
 	unsigned int color = flags & PFLAG_COLORS;
 	if (color == PFLAG_COLOR_RED)


### PR DESCRIPTION
Based on how nextColor was calculated before ef2a0c2, I'm retty sure PIPE's `nextColor` and `prevColor` should be swapped. Noticed this because id:2298562 didn't work with a very recent bleeding-edge build.