### PR TITLE
Fix dray with tmp=0 acting weirdly

### DIFF
--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -72,6 +72,7 @@ int Element_DRAY::update(UPDATE_FUNC_ARGS)
 					{
 						bool overwrite = parts[ID(r)].ctype == PT_PSCN;
 						int partsRemaining = copyLength, xCopyTo, yCopyTo; //positions where the line will start being copied at
+						int localCopyLength = copyLength;
 
 						if (parts[ID(r)].ctype == PT_INWR && rx && ry) // INWR doesn't spark from diagonals
 							continue;
@@ -106,10 +107,10 @@ int Element_DRAY::update(UPDATE_FUNC_ARGS)
 							//  1: if .tmp isn't set, and the element in this spot is the ctype, then stop
 							//  2: if .tmp is set, stop when the length limit reaches 0
 							//  3. Stop when we are out of bounds
-							if ((!copyLength && TYP(rr) == ctype && (ctype != PT_LIFE || parts[ID(rr)].ctype == ctypeExtra))
+							if ((!localCopyLength && TYP(rr) == ctype && (ctype != PT_LIFE || parts[ID(rr)].ctype == ctypeExtra))
 									|| !(--partsRemaining && InBounds(xCurrent+xStep, yCurrent+yStep)))
 							{
-								copyLength -= partsRemaining;
+								localCopyLength -= partsRemaining;
 								xCopyTo = xCurrent + xStep*copySpaces;
 								yCopyTo = yCurrent + yStep*copySpaces;
 								break;
@@ -117,7 +118,7 @@ int Element_DRAY::update(UPDATE_FUNC_ARGS)
 						}
 
 						// now, actually copy the particles
-						partsRemaining = copyLength + 1;
+						partsRemaining = localCopyLength + 1;
 						int type, p;
 						for (int xStep = rx*-1, yStep = ry*-1, xCurrent = x+xStep, yCurrent = y+yStep; InBounds(xCopyTo, yCopyTo) && --partsRemaining; xCurrent+=xStep, yCurrent+=yStep, xCopyTo+=xStep, yCopyTo+=yStep)
 						{


### PR DESCRIPTION
Under some conditions, DRAY doesn't copy as far as it should. See https://powdertoy.co.uk/Browse/View.html?ID=2312330 for an example.

Note that the issue title may not cover all the conditions under which the bug manifests. Also note that I have no idea how I fixed it; all I did was save a local variable from being altered multiple times and now DRAY seems to produce the expected behaviour.