### PR TITLE
Issue #602

### DIFF
--- a/src/simulation/elements/COAL.cpp
+++ b/src/simulation/elements/COAL.cpp
@@ -63,7 +63,7 @@ int Element_COAL::update(UPDATE_FUNC_ARGS)
 		else if (parts[i].tmp<40&&parts[i].tmp>0)
 			parts[i].tmp--;
 		else if (parts[i].tmp<=0) {
-			sim->create_part(i, x, y, PT_BCOL);
+			sim->part_change_type(i, x, y, PT_BCOL);
 			return 1;
 		}
 	}


### PR DESCRIPTION
Fixing a problem where decoration is not transferred from COAL to BCOL when broken. All properties of COAL should now be copied to the new BCOL particle, including if it is burning, decoration and discoloration caused from heating.