### PR TITLE
Fix part_change_type not being called by sim.partProperty

### DIFF
--- a/src/lua/LuaScriptInterface.cpp
+++ b/src/lua/LuaScriptInterface.cpp
@@ -2418,6 +2418,11 @@ void LuaScriptInterface::LuaSetProperty(lua_State* l, StructProperty property, i
 	switch (property.Type)
 	{
 		case StructProperty::ParticleType:
+			{
+				int partIndex = (Particle *)((unsigned char *)(propertyAddress) - property.Offset) - luacon_sim->parts;
+				luacon_sim->part_change_type(partIndex, luacon_sim->parts[partIndex].x+0.5f, luacon_sim->parts[partIndex].y+0.5f, luaL_checkinteger(l, stackPos));
+			}
+			break;
 		case StructProperty::Integer:
 			*((int*)propertyAddress) = luaL_checkinteger(l, stackPos);
 			break;

--- a/src/simulation/Particle.cpp
+++ b/src/simulation/Particle.cpp
@@ -5,8 +5,8 @@ std::vector<StructProperty> Particle::GetProperties()
 {
 	std::vector<StructProperty> properties;
 	properties.push_back(StructProperty("type", StructProperty::ParticleType, offsetof(Particle, type)));
-	properties.push_back(StructProperty("life", StructProperty::ParticleType, offsetof(Particle, life)));
-	properties.push_back(StructProperty("ctype", StructProperty::ParticleType, offsetof(Particle, ctype)));
+	properties.push_back(StructProperty("life", StructProperty::Integer, offsetof(Particle, life)));
+	properties.push_back(StructProperty("ctype", StructProperty::Integer, offsetof(Particle, ctype)));
 	properties.push_back(StructProperty("x", StructProperty::Float, offsetof(Particle, x)));
 	properties.push_back(StructProperty("y", StructProperty::Float, offsetof(Particle, y)));
 	properties.push_back(StructProperty("vx", StructProperty::Float, offsetof(Particle, vx)));


### PR DESCRIPTION
`sim.partProperty` not calling `part_change_type` when the property being set is `.type` causes bugs like stickmen spawning at random coordinates or not spawning at all.