### PR TITLE
Lua functions for managing zoom window

### DIFF
--- a/src/gui/game/GameModel.cpp
+++ b/src/gui/game/GameModel.cpp
@@ -783,7 +783,7 @@ bool GameModel::MouseInZoom(ui::Point position)
 	ui::Point zoomWindowPosition = GetZoomWindowPosition();
 	ui::Point zoomWindowSize = ui::Point(GetZoomSize()*zoomFactor, GetZoomSize()*zoomFactor);
 
-	if (position.X >= zoomWindowPosition.X && position.X >= zoomWindowPosition.Y && position.X <= zoomWindowPosition.X+zoomWindowSize.X && position.Y <= zoomWindowPosition.Y+zoomWindowSize.Y)
+	if (position.X >= zoomWindowPosition.X && position.Y >= zoomWindowPosition.Y && position.X <= zoomWindowPosition.X+zoomWindowSize.X && position.Y <= zoomWindowPosition.Y+zoomWindowSize.Y)
 		return true;
 	return false;
 }
@@ -797,7 +797,7 @@ ui::Point GameModel::AdjustZoomCoords(ui::Point position)
 	ui::Point zoomWindowPosition = GetZoomWindowPosition();
 	ui::Point zoomWindowSize = ui::Point(GetZoomSize()*zoomFactor, GetZoomSize()*zoomFactor);
 
-	if (position.X >= zoomWindowPosition.X && position.X >= zoomWindowPosition.Y && position.X <= zoomWindowPosition.X+zoomWindowSize.X && position.Y <= zoomWindowPosition.Y+zoomWindowSize.Y)
+	if (position.X >= zoomWindowPosition.X && position.Y >= zoomWindowPosition.Y && position.X <= zoomWindowPosition.X+zoomWindowSize.X && position.Y <= zoomWindowPosition.Y+zoomWindowSize.Y)
 		return ((position-zoomWindowPosition)/GetZoomFactor())+GetZoomPosition();
 	return position;
 }

--- a/src/lua/LuaScriptInterface.cpp
+++ b/src/lua/LuaScriptInterface.cpp
@@ -2292,8 +2292,10 @@ int LuaScriptInterface::renderer_zoomEnabled(lua_State * l)
 		lua_pushboolean(l, luacon_ren->zoomEnabled);
 		return 1;
 	}
-	else {
-		luacon_ren->zoomEnabled = luaL_optint(l, 1, 0);
+	else
+	{
+		luaL_checktype(l, -1, LUA_TBOOLEAN);
+		luacon_ren->zoomEnabled = lua_toboolean(l, -1);
 		return 0;
 	}
 }
@@ -2304,26 +2306,28 @@ int LuaScriptInterface::renderer_zoomWindowInfo(lua_State * l)
 		ui::Point location = luacon_ren->zoomWindowPosition;
 		lua_pushnumber(l, location.X);
 		lua_pushnumber(l, location.Y);
-		lua_pushnumber(l, luacon_ren->zoomScopeSize*luacon_ren->ZFACTOR);
 		lua_pushnumber(l, luacon_ren->ZFACTOR);
+		lua_pushnumber(l, luacon_ren->zoomScopeSize * luacon_ren->ZFACTOR);
 		return 4;
 	}
 	int x = luaL_optint(l, 1, 0);
 	int y = luaL_optint(l, 2, 0);
 	int f = luaL_optint(l, 3, 0);
-	if (luacon_ren->zoomScopeSize*f + x <= XRES && luacon_ren->zoomScopeSize*f + y <= YRES && x >= 0 && y >= 0) //To prevent crash when zoom window is outside screen
-	{
-		luacon_ren->zoomWindowPosition = ui::Point(x, y);
-		luacon_ren->ZFACTOR = f;
-		lua_pushboolean(l, true);
-		return 1;
-	}
-	lua_pushboolean(l, false);
-	return 1;
+	if (f <= 0)
+		return luaL_error(l, "Zoom factor must be greater than 0");
+
+	// To prevent crash when zoom window is outside screen
+	if (x < 0 || y < 0 || luacon_ren->zoomScopeSize * f + x > XRES || luacon_ren->zoomScopeSize * f + y > YRES)
+		return luaL_error(l, "Zoom window outside of bounds");
+
+	luacon_ren->zoomWindowPosition = ui::Point(x, y);
+	luacon_ren->ZFACTOR = f;
+	return 0;
 }
 int LuaScriptInterface::renderer_zoomScopeInfo(lua_State * l)
 {
-	if (lua_gettop(l) == 0) {
+	if (lua_gettop(l) == 0)
+	{
 		ui::Point location = luacon_ren->zoomScopePosition;
 		lua_pushnumber(l, location.X);
 		lua_pushnumber(l, location.Y);
@@ -2333,17 +2337,20 @@ int LuaScriptInterface::renderer_zoomScopeInfo(lua_State * l)
 	int x = luaL_optint(l, 1, 0);
 	int y = luaL_optint(l, 2, 0);
 	int s = luaL_optint(l, 3, 0);
-	if (luacon_ren->ZFACTOR*s + luacon_ren->zoomWindowPosition.X <= XRES && luacon_ren->ZFACTOR*s + luacon_ren->zoomWindowPosition.Y <= YRES
-		&& x >= 0 && y >= 0 && x <= XRES && y <= YRES) //To prevent crash when zoom or scope window is outside screen
-	{
-		luacon_ren->zoomScopePosition = ui::Point(x, y);
-		luacon_ren->zoomScopeSize = s;
-		lua_pushboolean(l, true);
-		return 1;
-	}
-	lua_pushboolean(l, false);
-	return 1;
+	if (s <= 0)
+		return luaL_error(l, "Zoom scope size must be greater than 0");
 
+	// To prevent crash when zoom or scope window is outside screen
+	int windowEdgeRight = luacon_ren->ZFACTOR * s + luacon_ren->zoomWindowPosition.X;
+	int windowEdgeBottom = luacon_ren->ZFACTOR * s + luacon_ren->zoomWindowPosition.Y;
+	if (x < 0 || y < 0 || x + s > XRES || y + s > YRES)
+		return luaL_error(l, "Zoom scope outside of bounds");
+	if (windowEdgeRight > XRES || windowEdgeBottom > YRES)
+		return luaL_error(l, "Zoom window outside of bounds");
+
+	luacon_ren->zoomScopePosition = ui::Point(x, y);
+	luacon_ren->zoomScopeSize = s;
+	return 0;
 }
 
 void LuaScriptInterface::initElementsAPI()

--- a/src/lua/LuaScriptInterface.h
+++ b/src/lua/LuaScriptInterface.h
@@ -121,6 +121,9 @@ class LuaScriptInterface: public CommandInterface
 	static int renderer_grid(lua_State * l);
 	static int renderer_debugHUD(lua_State * l);
 	static int renderer_depth3d(lua_State * l);
+	static int renderer_zoomEnabled(lua_State *l);
+	static int renderer_zoomWindowInfo(lua_State *l);
+	static int renderer_zoomScopeInfo(lua_State *l);
 
 	//Elements
 	void initElementsAPI();


### PR DESCRIPTION
Lua functions added:

bool ren.zoomEnabled()
   Returns true if zoom enabled.
nil ren.zoomEnabled(number)
   Enable or disable zoom.

number, number, number, number ren.zoomWindow()
   Returns: X, Y, WindowSize, ZoomFactor.
bool ren.zoomWindow(number, number, number)
   Set position and zoom factor of zoom window. Args: X, Y, ZoomFactor. Returns true if changes was successful, otherwise nothing changed to prevent game crash.

number, number, number ren.zoomScope()
   Returns: X, Y, Size of zoom scope.
bool ren.zoomScope(number, number, number)
   Set position and size of zoom scope. Args: X, Y, Size. Returns true if changes was successful, otherwise nothing changed to prevent game crash.

Also fixed typo that making mouse adjustment incorrect when zoom window Y coordinate is different than default.