### PR TITLE
Fix thumbnail rendering tasks being forcefully cleaned up

### DIFF
--- a/src/client/ThumbnailRendererTask.cpp
+++ b/src/client/ThumbnailRendererTask.cpp
@@ -1,4 +1,4 @@
-#include "ThumbnailRenderer.h"
+#include "ThumbnailRendererTask.h"
 
 #include <cmath>
 
@@ -47,8 +47,10 @@ bool ThumbnailRendererTask::doWork()
 	}
 }
 
-std::unique_ptr<VideoBuffer> ThumbnailRendererTask::GetThumbnail()
+std::unique_ptr<VideoBuffer> ThumbnailRendererTask::Finish()
 {
-	return std::move(thumbnail);
+	auto ptr = std::move(thumbnail);
+	AbandonableTask::Finish();
+	return ptr;
 }
 

--- a/src/client/ThumbnailRendererTask.h
+++ b/src/client/ThumbnailRendererTask.h
@@ -1,13 +1,13 @@
 #ifndef THUMBNAILRENDERER_H
 #define THUMBNAILRENDERER_H
 
-#include "tasks/Task.h"
+#include "tasks/AbandonableTask.h"
 
 #include <memory>
 
 class GameSave;
 class VideoBuffer;
-class ThumbnailRendererTask : public Task
+class ThumbnailRendererTask : public AbandonableTask
 {
 	std::unique_ptr<GameSave> Save;
 	int Width, Height;
@@ -21,7 +21,7 @@ public:
 	virtual ~ThumbnailRendererTask();
 
 	virtual bool doWork() override;
-	std::unique_ptr<VideoBuffer> GetThumbnail();
+	std::unique_ptr<VideoBuffer> Finish();
 };
 
 #endif // THUMBNAILRENDERER_H

--- a/src/gui/interface/SaveButton.h
+++ b/src/gui/interface/SaveButton.h
@@ -45,7 +45,7 @@ class SaveButton : public Component, public http::RequestMonitor<http::Thumbnail
 	bool isMouseInsideAuthor;
 	bool isMouseInsideHistory;
 	bool showVotes;
-	std::unique_ptr<ThumbnailRendererTask> thumbnailRenderer;
+	ThumbnailRendererTask *thumbnailRenderer;
 public:
 	SaveButton(Point position, Point size, SaveInfo * save);
 	SaveButton(Point position, Point size, SaveFile * file);

--- a/src/gui/save/LocalSaveActivity.h
+++ b/src/gui/save/LocalSaveActivity.h
@@ -24,7 +24,7 @@ public:
 class LocalSaveActivity: public WindowActivity
 {
 	SaveFile save;
-	std::unique_ptr<ThumbnailRendererTask> thumbnailRenderer;
+	ThumbnailRendererTask *thumbnailRenderer;
 	std::unique_ptr<VideoBuffer> thumbnail;
 	ui::Textbox * filenameField;
 	class CancelAction;

--- a/src/gui/save/ServerSaveActivity.h
+++ b/src/gui/save/ServerSaveActivity.h
@@ -40,7 +40,7 @@ public:
 protected:
 	void AddAuthorInfo();
 	virtual void NotifyDone(Task * task);
-	std::unique_ptr<ThumbnailRendererTask> thumbnailRenderer;
+	ThumbnailRendererTask *thumbnailRenderer;
 	std::unique_ptr<VideoBuffer> thumbnail;
 	SaveInfo save;
 	SaveUploadedCallback * callback;

--- a/src/tasks/AbandonableTask.cpp
+++ b/src/tasks/AbandonableTask.cpp
@@ -1,0 +1,163 @@
+#include "AbandonableTask.h"
+
+#include "Platform.h"
+
+#ifdef DEBUG
+# define DEBUGTHREADS
+// * Uncomment above if AbandonableTasks cause issues.
+// * Three outputs should be possible:
+//   * The task is properly finished:
+//       AbandonableTask @ [ptr] ctor
+//       AbandonableTask @ [ptr] created
+//       ...
+//       AbandonableTask @ [ptr] finished
+//       AbandonableTask @ [ptr] joined
+//       AbandonableTask @ [ptr] dtor
+//   * The task is abandoned but its thread has finished:
+//       AbandonableTask @ [ptr] ctor
+//       AbandonableTask @ [ptr] created
+//       ...
+//       AbandonableTask @ [ptr] abandoned
+//       AbandonableTask @ [ptr] joined
+//       AbandonableTask @ [ptr] dtor
+//   * The task is abandoned before its thread has finished:
+//       AbandonableTask @ [ptr] ctor
+//       AbandonableTask @ [ptr] created
+//       ...
+//       AbandonableTask @ [ptr] abandoned
+//       ...
+//       AbandonableTask @ [ptr] detached
+//       AbandonableTask @ [ptr] dtor
+// * Anything other than those means something is broken.
+#endif
+
+#ifdef DEBUGTHREADS
+# include <iostream>
+#endif
+
+void AbandonableTask::Start()
+{
+	thDone = false;
+	done = false;
+	thAbandoned = false;
+	progress = 0;
+	status = "";
+	//taskMutex = PTHREAD_MUTEX_INITIALIZER;
+	before();
+	pthread_mutex_init (&taskMutex, NULL);
+	pthread_create(&doWorkThread, 0, &AbandonableTask::doWork_helper, this);
+
+#ifdef DEBUGTHREADS
+		std::cerr << "AbandonableTask @ " << this << " created" << std::endl;
+#endif
+}
+
+TH_ENTRY_POINT void * AbandonableTask::doWork_helper(void * ref)
+{
+	Task::doWork_helper(ref);
+
+	AbandonableTask *task = (AbandonableTask *)ref;
+	pthread_mutex_lock(&task->taskMutex);
+	bool abandoned = task->thAbandoned;
+	pthread_mutex_unlock(&task->taskMutex);
+	if (abandoned)
+	{
+		pthread_detach(task->doWorkThread);
+		pthread_mutex_destroy(&task->taskMutex);
+
+#ifdef DEBUGTHREADS
+		std::cerr << "AbandonableTask @ " << ref << " detached" << std::endl;
+#endif
+
+		// We've done Task::~Task's job already.
+		task->done = true;
+
+		delete task;
+	}
+	return NULL;
+}
+
+void AbandonableTask::Finish()
+{
+	while (!GetDone())
+	{
+		Poll();
+		Platform::Millisleep(1);
+	}
+
+#ifdef DEBUGTHREADS
+	std::cerr << "AbandonableTask @ " << this << " finished" << std::endl;
+#endif
+
+	delete this;
+}
+
+void AbandonableTask::Abandon()
+{
+	bool delete_this = false;
+	pthread_mutex_lock(&taskMutex);
+	if (thDone)
+	{
+		// If thDone is true, the thread has already finished. We're
+		// not calling Poll because it may call callbacks, which
+		// an abandoned task shouldn't do. Instead we just delete the
+		// AbandonableTask after unlocking the mutex, which will
+		// take care of the thread if another Poll hasn't already
+		// (i.e. if done is false despite thDone being true).
+		delete_this = true;
+	}
+	else
+	{
+		// If at this point thDone is still false, the thread is still
+		// running, meaning we can safely set thAbandoned and let
+		// AbandonableTask::doWork_helper detach the thread
+		// and delete the AbandonableTask later.
+		thAbandoned = true;
+	}
+	pthread_mutex_unlock(&taskMutex);
+
+#ifdef DEBUGTHREADS
+	std::cerr << "AbandonableTask @ " << this << " abandoned" << std::endl;
+#endif
+
+	if (delete_this)
+	{
+		delete this;
+	}
+}
+
+void AbandonableTask::Poll()
+{
+#ifdef DEBUGTHREADS
+	bool old_done = done;
+#endif
+	Task::Poll();
+#ifdef DEBUGTHREADS
+	if (done != old_done)
+	{
+		std::cerr << "AbandonableTask @ " << this << " joined" << std::endl;
+	}
+#endif
+}
+
+AbandonableTask::AbandonableTask()
+{
+#ifdef DEBUGTHREADS
+	std::cerr << "AbandonableTask @ " << this << " ctor" << std::endl;
+#endif
+}
+
+AbandonableTask::~AbandonableTask()
+{
+#ifdef DEBUGTHREADS
+	if (!done)
+	{
+		// Actually it'll be joined later in Task::~Task, but the debug
+		// messages look more consistent this way.
+		std::cerr << "AbandonableTask @ " << this << " joined" << std::endl;
+	}
+
+	std::cerr << "AbandonableTask @ " << this << " dtor" << std::endl;
+#endif
+}
+

--- a/src/tasks/AbandonableTask.h
+++ b/src/tasks/AbandonableTask.h
@@ -1,0 +1,21 @@
+#ifndef ABANDONABLETASK_H_
+#define ABANDONABLETASK_H_
+
+#include "Task.h"
+
+class AbandonableTask : public Task
+{
+public:
+	void Start();
+	void Finish();
+	void Abandon();
+	void Poll();
+	AbandonableTask();
+	virtual ~AbandonableTask();
+
+protected:
+	bool thAbandoned;
+	TH_ENTRY_POINT static void * doWork_helper(void * ref);
+};
+
+#endif /* ABANDONABLETASK_H_ */


### PR DESCRIPTION
Thumbnail rendering can't be cancelled, so a thumbnail rendering task shouldn't be owned by the object requesting the thumbnail. `ThumbnailRendererTask` is now derived from `AbandonableTask` instead.

`AbandonableTask` is an abandonable version of `Task`: whatever spawns it (with `new`) isn't considered to be its owner. Instead, when the spawner object detects that the task has finished, it may call `Finish`, which cleans up the task. Alternatively, it may also call `Abandon` at any point, which doesn't cancel the task, but marks it to be cleaned up whenever it's finished.