### PR TITLE
Fix race condition in Gravity.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ config.log
 *.pyc
 site_scons/site_tools/mfprogram/*.pyc
 site_scons/site_tools/gch/*.pyc
+.vscode/ipch
 
 screenshot_*


### PR DESCRIPTION
There is a race condition in Gravity.cpp where the gravity update thread will deadlock if pthread_cond_signal (in gravity_update_async) from the main thread occurs when the gravity update thread (in update_grav_async) has not yet called pthread_cond_wait. This can occur when pthread_cond_signal happens between the end of the first if branch and the beginning of the second if branch, where the mutex is briefly released by the gravity update thread.

Enables newtonian gravity to work on webassembly.
Also add vscode c/c++ temporary data directory to .gitignore.
@LBPHacker what did i mess up