### PR TITLE
Fix race condition in SaveRenderer.cpp

### DIFF
--- a/src/simulation/SaveRenderer.cpp
+++ b/src/simulation/SaveRenderer.cpp
@@ -6,6 +6,8 @@
 
 
 SaveRenderer::SaveRenderer(){
+	pthread_mutex_init(&renderMutex, NULL);
+	pthread_mutex_lock(&renderMutex);
 	g = new Graphics();
 	sim = new Simulation();
 	ren = new Renderer(g, sim);
@@ -30,7 +32,7 @@ SaveRenderer::SaveRenderer(){
 	glDisable(GL_TEXTURE_2D);
 #endif
 
-	pthread_mutex_init(&renderMutex, NULL);
+	pthread_mutex_unlock(&renderMutex);
 }
 
 VideoBuffer * SaveRenderer::Render(GameSave * save, bool decorations, bool fire)


### PR DESCRIPTION
There is a possibility that SaveRenderer::Render will be called while the SaveRenderer constructor is still running. In this case, SaveRenderer::Renderer will end up getting a null pointer for the Simulation object, will try to call Simulation::clear_sim, and segfault (or in my case, overwrite a whole bunch of emscripten stack data with zeroes). 
This fix acquires the mutex in the SaveRenderer constructor, therefore preventing SaveRenderer::Render from using an unfinished instance.
Edit: grammar
Edit 2: [LOOK AT THIS CRAP IT ACTUALLY WORKS](https://hellomouse.net/static/tpt.html)