### PR TITLE
Fix namespace error

### DIFF
--- a/src/PowderToySDL.cpp
+++ b/src/PowderToySDL.cpp
@@ -849,7 +849,7 @@ int main(int argc, char * argv[])
 
 #if !defined(DEBUG) && !defined(_DEBUG)
 	}
-	catch(exception& e)
+	catch(std::exception& e)
 	{
 		BlueScreen(ByteString(e.what()).FromUtf8());
 	}


### PR DESCRIPTION
Fix namespace error when compiling with the "--debugging" flag (default flags).